### PR TITLE
If available, use isal.igzip (from the Intelligent Storage Acceleration Library) to significantly accelerate compression/decompression

### DIFF
--- a/pgzip/pgzip.py
+++ b/pgzip/pgzip.py
@@ -11,21 +11,22 @@ import builtins
 import struct
 import zlib
 import io
-from gzip import (
-    GzipFile,
-    write32u,
-    _GzipReader,
-    _PaddedFile,
-    READ,
-    WRITE,
-    FEXTRA,
-    FNAME,
-    FCOMMENT,
-    FHCRC,
-)
+try:
+    from isal.igzip import (
+        GzipFile,
+        _GzipReader,
+        _PaddedFile,
+    )
+except ImportError:
+    from gzip import (
+        GzipFile,
+        _GzipReader,
+        _PaddedFile,
+    )
+from gzip import write32u, READ, WRITE, FEXTRA, FNAME, FCOMMENT, FHCRC
 from multiprocessing.dummy import Pool
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 SID = b"IG"  # Subfield ID of indexed gzip file
 
@@ -702,7 +703,7 @@ class _MulitGzipReader(_GzipReader):
             buf = self._fp.read(io.DEFAULT_BUFFER_SIZE)
 
             uncompress = self._decompressor.decompress(buf, size)
-            if self._decompressor.unconsumed_tail != b"":
+            if getattr(self._decompressor, "unconsumed_tail", b"") != b"":
                 self._fp.prepend(self._decompressor.unconsumed_tail)
             elif self._decompressor.unused_data != b"":
                 # Prepend the already read bytes to the fileobj so they can


### PR DESCRIPTION
If the user also has the `isal` library available for import, take advantage of `isal.igzip` for a _substantial_ speedup in all compression/decompression operations. 

(Note: `IgzipDecompressor` doesn't currently expose an `unconsumed_tail` attribute, as the underlying design doesn't require it, so in this case `_decompressor.unconsumed_tail` (in pgzip) would always be `b""` - accounted for this with a minor tweak).

See also: 
* https://github.com/pycompression/python-isal/
* https://github.com/intel/isa-l